### PR TITLE
Make it work for Rails 6 and above; fix a couple of nil errors

### DIFF
--- a/lib/annotate_controllers/annotator.rb
+++ b/lib/annotate_controllers/annotator.rb
@@ -60,20 +60,22 @@ module AnnotateControllers
 
       def prefix_or_shared(prefixes, verb, prefix, action)
         if prefix.present?
-          ' (' + prefix + '_path)'
+          " (#{prefix}_path)"
         else
           shared_prefix(prefixes, verb, action)
         end
       end
 
       def shared_prefix(prefixes, verb, action)
-        if VERBS.include? verb
-          ' (' +
-          prefixes.detect{ |l| l[:action] == shared_action_prefix(action) }.try(:[], :prefix) +
-          '_path)'
-        else
-          ''
-        end
+        return '' unless VERBS.include? verb
+
+        prefix = prefixes.detect { |l|
+          l[:action] == shared_action_prefix(action)
+        }.try(:[], :prefix)
+
+        return '' unless prefix
+
+        " (#{prefix}_path)"
       end
 
       def shared_action_prefix(action)

--- a/lib/annotate_controllers/inspector.rb
+++ b/lib/annotate_controllers/inspector.rb
@@ -2,22 +2,18 @@ require 'action_dispatch/routing/inspector'
 
 module AnnotateControllers
   class Inspector
-
     class << self
-
       def map_all_routes
         all_routes = Rails.application.routes.routes
         inspector = ActionDispatch::Routing::RoutesInspector.new(all_routes)
-        remove_constraints(
-          inspector.format(ActionDispatch::Routing::ConsoleFormatter::Sheet.new).split("\n").drop(1)
-        )
+        formatter = ActionDispatch::Routing::ConsoleFormatter::Sheet.new
+        routes = inspector.format(formatter).split("\n").drop(1)
+        remove_constraints(routes)
       end
 
       def remove_constraints(routes)
-        routes.each{ |r| r.slice!(/ \{(.*)}/) }
+        routes.each { |r| r.slice!(/ \{(.*)}/) }
       end
-
     end
-
   end
 end

--- a/lib/annotate_controllers/inspector.rb
+++ b/lib/annotate_controllers/inspector.rb
@@ -9,7 +9,7 @@ module AnnotateControllers
         all_routes = Rails.application.routes.routes
         inspector = ActionDispatch::Routing::RoutesInspector.new(all_routes)
         remove_constraints(
-          inspector.format(ActionDispatch::Routing::ConsoleFormatter.new).split("\n").drop(1)
+          inspector.format(ActionDispatch::Routing::ConsoleFormatter::Sheet.new).split("\n").drop(1)
         )
       end
 

--- a/lib/annotate_controllers/inspector.rb
+++ b/lib/annotate_controllers/inspector.rb
@@ -8,7 +8,7 @@ module AnnotateControllers
         inspector = ActionDispatch::Routing::RoutesInspector.new(all_routes)
         formatter = ActionDispatch::Routing::ConsoleFormatter::Sheet.new
         routes = inspector.format(formatter).split("\n").drop(1)
-        remove_constraints(routes)
+        remove_constraints(routes).reject(&:empty?)
       end
 
       def remove_constraints(routes)


### PR DESCRIPTION
1. In Rails 6+, `ActionDispatch::Routing::ConsoleFormatter ` [is a module, not a class](https://api.rubyonrails.org/classes/ActionDispatch/Routing/ConsoleFormatter.html) (if I understood correctly, the `Sheet` class retains previous functionality; I got some empty strings in testing, not sure if it's because of some formatter change or just my wierd routes)
2. When the route prefixes are not set (i. e. when using non-resourceful routes and not assigning prefixes manually), previous version led to nil errors and (if you ignore nils, e. g. with using string interpolation instead on concatenating) `(_path)` annotations, so I return an empty string instead whenever a route doesn't have a prefix.

I wonder why this gem (or any gem like it) doesn't see development, seems like a useful tool to me.